### PR TITLE
adminページで、ユーザーを表示してstatusの変更ができるようにまで

### DIFF
--- a/src/components/feature/MemberCard/MemberCard.tsx
+++ b/src/components/feature/MemberCard/MemberCard.tsx
@@ -4,38 +4,7 @@ import Link from "next/link";
 import { GitHubIcon, TwitterIcon, InstagramIcon } from "src/components/ui-libraries/icon";
 import { CurrentUser, useCurrentUser } from "src/global-states/atoms";
 import { fieldDetailsData } from "src/components/utils/constants/field";
-
-type UniAndBioProps = {
-  bio: string;
-  university: string;
-  faculty: string | null;
-  grade: string | null;
-};
-export const UniAndBio: FC<UniAndBioProps> = ({ bio, university, faculty, grade }) => {
-  return (
-    <div className="rounded-lg py-1  px-2">
-      <div className="flex">
-        <div className="flex flex-col">
-          <p className="font-bold text-gray-400">uni</p>
-          <p>{university}</p>
-        </div>
-        <div className="px-2">
-          <p className="font-bold text-gray-400">faculty</p>
-          <p>{faculty}</p>
-        </div>
-        <div className="px-2">
-          <p className="font-bold text-gray-400">grade</p>
-          <span>{grade}</span>
-        </div>
-      </div>
-
-      <div className="mt-2">
-        <p className="font-bold text-gray-400">自己紹介</p>
-        <p className="w-full truncate">{bio}</p>
-      </div>
-    </div>
-  );
-};
+import { MemberProfileIcon } from "./MemberProfileIcon";
 
 type FieldInterestProps = {
   field: string;
@@ -159,19 +128,6 @@ const Profile: FC<ProfileProps> = memo(({ size, isAdmin }) => {
 });
 Profile.displayName = "Profile";
 
-type ProfileImgProps = {
-  displayName: string | undefined;
-  photoURL: string | undefined;
-};
-export const ProfileImg: FC<ProfileImgProps> = ({ displayName, photoURL }) => {
-  return (
-    <div>
-      <img src={photoURL} alt={`${displayName}の画像`} className={`w-12 rounded-full`} />
-      <p className="pt-1 text-xs ">{displayName}</p>
-    </div>
-  );
-};
-
 type AdminCardProps = Omit<CurrentUser, "uid" | "createdAt" | "email">;
 
 export const ComitteeCard: FC<AdminCardProps> = memo(({ field, position, fieldDetails }) => {
@@ -193,7 +149,7 @@ ComitteeCard.displayName = "ComitteeCard";
 
 export const ActiveMemberCard = () => {
   return (
-    <div className="relative w-[36em] rounded-md  bg-white py-6 px-4 shadow-md hover:bg-gray-50">
+    <div className="relative w-[36em] rounded-md bg-white py-6 px-4 shadow-md hover:bg-gray-50">
       <div className="grid grid-flow-row grid-cols-5">
         <div className="flex flex-col items-center justify-between">
           <Profile size={"w-16 h-16"} isAdmin={false} />
@@ -204,13 +160,15 @@ export const ActiveMemberCard = () => {
   );
 };
 
-type MemberCardProps = { data: Pick<CurrentUser, "displayName" | "photoURL" | "uid"> };
+type MemberCardProps = {
+  data: Pick<CurrentUser, "displayName" | "photoURL" | "uid">;
+};
+
 export const MemberCard: FC<MemberCardProps> = ({ data }) => {
-  if (!data) return null;
   return (
     <Link href={`member/${data.uid}`} className="cursor-pointer">
       <a>
-        <ProfileImg displayName={data.displayName} photoURL={data?.photoURL} />
+        <MemberProfileIcon displayName={data.displayName} photoURL={data?.photoURL} />
       </a>
     </Link>
   );

--- a/src/components/feature/MemberCard/MemberProfileIcon.tsx
+++ b/src/components/feature/MemberCard/MemberProfileIcon.tsx
@@ -1,0 +1,16 @@
+/* eslint-disable @next/next/no-img-element */
+import { FC } from "react";
+
+type ProfileImgProps = {
+  displayName: string | undefined;
+  photoURL: string | undefined;
+};
+
+export const MemberProfileIcon: FC<ProfileImgProps> = ({ displayName, photoURL }) => {
+  return (
+    <div>
+      <img src={photoURL} alt={`${displayName}の画像`} className="w-12 rounded-full" />
+      <p className="pt-1 text-xs">{displayName}</p>
+    </div>
+  );
+};

--- a/src/components/feature/MemberStatusEditContentsModal.tsx
+++ b/src/components/feature/MemberStatusEditContentsModal.tsx
@@ -1,0 +1,71 @@
+import { FC, useState } from "react";
+import { Modal as MantineModal, Select } from "@mantine/core";
+import { doc, DocumentReference, updateDoc } from "firebase/firestore";
+import { CurrentUser } from "src/global-states/atoms";
+import { db } from "../utils/libs/firebase";
+import { statusData } from "../utils/constants/field";
+import { AppButton } from "../ui-libraries/AppButton";
+
+type Props = {
+  user: CurrentUser;
+  opened: boolean;
+  setOpened: () => void;
+};
+
+export type FormData = Omit<CurrentUser, "uid" | "createdAt" | "id" | "active">;
+
+export const MemberStatusEditContentsModal: FC<Props> = ({ user, opened, setOpened }) => {
+  const [status, setStatus] = useState<number>(user.status);
+
+  const userRef = doc(db, "users", user.uid) as DocumentReference<CurrentUser>;
+
+  const handleSave = async () => {
+    await updateDoc(userRef, { status });
+    setOpened();
+  };
+
+  const statusBody = () => {
+    switch (user.status) {
+      case 1:
+        return { status: 1, message: "登録済み" };
+      case 2:
+        return { status: 2, message: "退会済み" };
+      default:
+        return { status: 0, message: "未登録" };
+    }
+  };
+
+  return (
+    <MantineModal
+      opened={opened}
+      onClose={setOpened}
+      title="設定"
+      size="xl"
+      overlayOpacity={0.55}
+      overlayBlur={3}
+      overflow="inside"
+      radius={10}
+    >
+      <Select
+        required
+        label="Statusを変更"
+        placeholder="選択してください"
+        data={statusData}
+        className="mt-4"
+        value={String(statusBody().status)}
+        dropdownComponent="div"
+        onChange={(e) => {
+          setStatus(Number(e));
+        }}
+      />
+
+      <div className="mt-5 w-full text-center">
+        <AppButton type="button" color="blue" size="md" radius="md" variant="filled" className="" onClick={handleSave}>
+          保存
+        </AppButton>
+      </div>
+    </MantineModal>
+  );
+};
+
+// todo: 最も興味のある分野を選んだら、fieldDetailsが連動するようにする

--- a/src/components/feature/ProfileEditContentsModal.tsx
+++ b/src/components/feature/ProfileEditContentsModal.tsx
@@ -30,7 +30,7 @@ type Props = {
 
 export type FormData = Omit<CurrentUser, "uid" | "createdAt" | "id" | "active">;
 
-export const SettingModal: FC<Props> = ({ currentUser, setCurrentUser, opened, setOpened }) => {
+export const ProfileEditContentsModal: FC<Props> = ({ currentUser, setCurrentUser, opened, setOpened }) => {
   const router = useRouter();
   const [formData, setFormData] = useState<FormData>({
     bio: currentUser.bio,
@@ -296,5 +296,3 @@ export const SettingModal: FC<Props> = ({ currentUser, setCurrentUser, opened, s
     </MantineModal>
   );
 };
-
-// todo: 最も興味のある分野を選んだら、fieldDetailsが連動するようにする

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -5,9 +5,9 @@ import Image from "next/image";
 import { Avatar } from "@mantine/core";
 import { useCurrentUser } from "src/global-states/atoms";
 import { BellIcon, CalendarIcon } from "../ui-libraries/icon";
-import { SettingModal } from "../feature/SettingModal";
 import { LINKS } from "../utils/constants/link";
 import { NotificationModal } from "../feature/NotificationModal";
+import { ProfileEditContentsModal } from "../feature/ProfileEditContentsModal";
 
 export const NavItem: FC = memo(() => {
   const { currentUser, setCurrentUser } = useCurrentUser();
@@ -44,7 +44,7 @@ export const NavItem: FC = memo(() => {
           <Avatar src={null} radius="xl" size={40} className="hover:opacity-80" alt="ゲスト" />
         )}
       </button>
-      <SettingModal
+      <ProfileEditContentsModal
         currentUser={currentUser}
         setCurrentUser={setCurrentUser}
         opened={settingOpened}

--- a/src/components/page/Admin/AdminDetail.tsx
+++ b/src/components/page/Admin/AdminDetail.tsx
@@ -1,0 +1,86 @@
+import { doc, getDoc } from "firebase/firestore";
+import { FC, useEffect, useState } from "react";
+import { useRouter } from "next/router";
+import { InterestGroup, MemberSNSLink } from "src/components/feature/MemberCard/MemberCard";
+import { MemberProfileIcon } from "src/components/feature/MemberCard/MemberProfileIcon";
+import { db } from "src/components/utils/libs/firebase";
+import { CurrentUser } from "src/global-states/atoms";
+import { AppLoading } from "src/components/ui-libraries/AppLoading";
+import { Layout } from "src/components/layout";
+import { MemberStatusEditContentsModal } from "src/components/feature/MemberStatusEditContentsModal";
+
+export const AdminDetail: FC = () => {
+  const [user, setUser] = useState<CurrentUser>();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isOpen, setIsOpen] = useState<boolean>(false);
+  const router = useRouter();
+  const handleOpen = () => {
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (router.isReady) {
+      try {
+        const getUser = async () => {
+          const docRef = doc(db, `users/${router.query.id}`);
+          const user = await getDoc(docRef);
+          setUser(user.data() as CurrentUser);
+        };
+        getUser();
+      } finally {
+        setIsLoading(false);
+      }
+    }
+  }, [router.query.id]);
+
+  if (isLoading || user == null) return <AppLoading />;
+
+  const status = () => {
+    switch (user.status) {
+      case 1:
+        return "登録済み";
+      case 2:
+        return "退会";
+      default:
+        return "未登録";
+    }
+  };
+
+  return (
+    <>
+      <MemberStatusEditContentsModal user={user} opened={isOpen} setOpened={handleOpen} />
+      <Layout>
+        <MemberProfileIcon displayName={user.displayName} photoURL={user.photoURL} />
+        <InterestGroup field={user.field} fieldDetails={user.fieldDetails} />
+        <MemberSNSLink github={user.github} twitter={user.twitter} instagram={user?.instagram} />
+        <div className="rounded-lg py-1 px-2">
+          <div className="flex">
+            <div className="flex flex-col">
+              <p className="font-bold text-gray-400">uni</p>
+              <p>{user.university}</p>
+            </div>
+            <div className="px-2">
+              <p className="font-bold text-gray-400">faculty</p>
+              <p>{user.faculty}</p>
+            </div>
+            <div className="px-2">
+              <p className="font-bold text-gray-400">grade</p>
+              <span>{user.grade}</span>
+            </div>
+          </div>
+          <div className="mt-2">
+            <p className="font-bold text-gray-400">自己紹介</p>
+            <p className="w-full truncate">{user.bio}</p>
+          </div>
+          <div
+            onClick={() => {
+              setIsOpen(true);
+            }}
+          >
+            {status()}
+          </div>
+        </div>
+      </Layout>
+    </>
+  );
+};

--- a/src/components/page/Admin/index.tsx
+++ b/src/components/page/Admin/index.tsx
@@ -1,0 +1,56 @@
+/* eslint-disable @next/next/no-img-element */
+import { collection, getDocs } from "firebase/firestore";
+import Link from "next/link";
+import { FC, useEffect, useState } from "react";
+import { Layout } from "src/components/layout";
+import { db } from "src/components/utils/libs/firebase";
+import { CurrentUser } from "src/global-states/atoms";
+
+export const Admin: FC = () => {
+  const [users, setUsers] = useState<CurrentUser[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    try {
+      const getUsers = async () => {
+        const colRef = collection(db, "users");
+        const users = await getDocs(colRef);
+        setUsers(users.docs.map((doc) => doc.data() as CurrentUser));
+      };
+      getUsers();
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading]);
+
+  return (
+    <Layout>
+      <div className="mt-4 flex gap-4">
+        {users.map((user) => {
+          const status = () => {
+            switch (user.status) {
+              case 1:
+                return "登録済み";
+              case 2:
+                return "退会";
+              default:
+                return "未登録";
+            }
+          };
+
+          return (
+            <>
+              <Link key={user.uid} href={`admin/${user.uid}`}>
+                <a className="flex flex-col items-center justify-center gap-5 rounded-md bg-white py-6 px-4 shadow-md hover:cursor-pointer hover:bg-slate-50">
+                  <img src={user.photoURL} alt={`${user.displayName}の画像`} className="h-16 w-16 rounded-full" />
+                  <p className="w-40 truncate pt-1 text-center text-sm font-bold">{user.displayName}</p>
+                  <div>{status()}</div>
+                </a>
+              </Link>
+            </>
+          );
+        })}
+      </div>
+    </Layout>
+  );
+};

--- a/src/components/page/Member/MemberDetail.tsx
+++ b/src/components/page/Member/MemberDetail.tsx
@@ -4,35 +4,57 @@ import { doc, getDoc } from "firebase/firestore";
 import { Layout } from "src/components/layout";
 import { db } from "src/components/utils/libs/firebase";
 import { CurrentUser } from "src/global-states/atoms";
-import { InterestGroup, MemberSNSLink, ProfileImg, UniAndBio } from "src/components/feature/MemberCard/MemberCard";
+import { InterestGroup, MemberSNSLink } from "src/components/feature/MemberCard/MemberCard";
 import { AppLoading } from "src/components/ui-libraries/AppLoading";
+import { MemberProfileIcon } from "src/components/feature/MemberCard/MemberProfileIcon";
 
 export const MemberDetail = () => {
   const [user, setUser] = useState<CurrentUser>();
   const [isLoading, setIsLoading] = useState(true);
-
-  const uid = useRouter().query.id;
+  const router = useRouter();
 
   useEffect(() => {
-    try {
-      const getUser = async () => {
-        const docRef = doc(db, `users/${uid}`);
-        const user = (await getDoc(docRef)).data();
-        setUser(user as CurrentUser);
-      };
-      getUser();
-    } finally {
-      setIsLoading(false);
+    if (router.isReady) {
+      try {
+        const getUser = async () => {
+          const docRef = doc(db, `users/${router.query.id}`);
+          const user = (await getDoc(docRef)).data();
+          setUser(user as CurrentUser);
+        };
+        getUser();
+      } finally {
+        setIsLoading(false);
+      }
     }
-  }, [uid]);
+  }, [router.query.id]);
 
   if (isLoading || user == null) return <AppLoading />;
+
   return (
     <Layout>
-      <ProfileImg displayName={user?.displayName} photoURL={user?.photoURL} />
+      <MemberProfileIcon displayName={user.displayName} photoURL={user.photoURL} />
       <InterestGroup field={user?.field} fieldDetails={user?.fieldDetails} />
       <MemberSNSLink github={user?.github} twitter={user?.twitter} instagram={user?.instagram} />
-      <UniAndBio bio={user?.bio} university={user?.university} faculty={user?.faculty} grade={user?.grade} />
+      <div className="rounded-lg py-1 px-2">
+        <div className="flex">
+          <div className="flex flex-col">
+            <p className="font-bold text-gray-400">uni</p>
+            <p>{user.university}</p>
+          </div>
+          <div className="px-2">
+            <p className="font-bold text-gray-400">faculty</p>
+            <p>{user.faculty}</p>
+          </div>
+          <div className="px-2">
+            <p className="font-bold text-gray-400">grade</p>
+            <span>{user.grade}</span>
+          </div>
+        </div>
+        <div className="mt-2">
+          <p className="font-bold text-gray-400">自己紹介</p>
+          <p className="w-full truncate">{user.bio}</p>
+        </div>
+      </div>
     </Layout>
   );
 };

--- a/src/components/utils/constants/field.ts
+++ b/src/components/utils/constants/field.ts
@@ -25,3 +25,9 @@ export const fieldDetailsData = [
   { value: "AWS", label: "AWS", color: "black" },
   { value: "GCP", label: "GCP", color: "red" },
 ];
+
+export const statusData = [
+  { value: "0", label: "審査中" },
+  { value: "1", label: "登録済み" },
+  { value: "2", label: "退会済み" },
+];

--- a/src/hooks/useUploadProfileIcon.ts
+++ b/src/hooks/useUploadProfileIcon.ts
@@ -3,7 +3,7 @@ import { ref, uploadBytesResumable, getDownloadURL } from "firebase/storage";
 import { ChangeEvent, useState } from "react";
 import { storage } from "src/components/utils/libs/firebase";
 import { useCurrentUser } from "src/global-states/atoms";
-import { FormData } from "src/components/feature/SettingModal";
+import { FormData } from "src/components/feature/ProfileEditContentsModal";
 
 type Props = {
   formData: FormData;

--- a/src/pages/admin/[id].tsx
+++ b/src/pages/admin/[id].tsx
@@ -1,0 +1,8 @@
+import { NextPage } from "next";
+import { AdminDetail } from "src/components/page/Admin/AdminDetail";
+
+const AdminDetailPage: NextPage = () => {
+  return <AdminDetail />;
+};
+
+export default AdminDetailPage;

--- a/src/pages/admin/index.tsx
+++ b/src/pages/admin/index.tsx
@@ -1,0 +1,8 @@
+import { NextPage } from "next";
+import { Admin } from "src/components/page/Admin";
+
+const AdminPage: NextPage = () => {
+  return <Admin />;
+};
+
+export default AdminPage;


### PR DESCRIPTION
### 内容

- /adminで、ユーザー一覧表示
- /admin/[id]で、ユーザーの詳細ページに遷移
  - statusの変更ができるように
  - でもこれ、複数人の変更とかする場合考えたら毎回遷移するのだるいから、モーダルに変えたほうがいいかも

### やってないこと
- admin側ページを見れるユーザーの制限
- レイアウト整える
- とりあえず実装だけしたので、コードぐちゃぐちゃ
  - ユーザー取得するロジックとか全く同じ処理書いてる