### PR TITLE
Firebaseとの依存関係の改善

### DIFF
--- a/src/components/feature/Member/MemberProfileIcon.tsx
+++ b/src/components/feature/Member/MemberProfileIcon.tsx
@@ -8,9 +8,9 @@ type ProfileImgProps = {
 
 export const MemberProfileIcon: FC<ProfileImgProps> = ({ displayName, photoURL }) => {
   return (
-    <div>
+    <div className="flex flex-col items-center justify-center">
       <img src={photoURL} alt={`${displayName}の画像`} className="w-12 rounded-full" />
-      <p className="pt-1 text-xs">{displayName}</p>
+      <p className="w-20 truncate pt-1 text-center text-xs">{displayName}</p>
     </div>
   );
 };

--- a/src/components/page/Member/index.tsx
+++ b/src/components/page/Member/index.tsx
@@ -1,68 +1,70 @@
-import { collection, getDocs } from "firebase/firestore";
-import { useState, useEffect, FC, Suspense } from "react";
+import { useEffect, FC } from "react";
 import { Text } from "@mantine/core";
 import { ComitteeCard, MemberCard } from "src/components/feature/Member/MemberCard";
 import { Layout } from "src/components/layout";
 import { AppLoading } from "src/components/ui-libraries/AppLoading";
-import { db } from "src/components/utils/libs/firebase";
 import { useCurrentUser } from "src/global-states/atoms";
-import { User } from "src/components/utils/libs/firebase/index";
+import { useFetchMembers } from "src/hooks/user/useFetchUserList";
+import { User } from "src/modules/user/user.entity";
 
 export const Member: FC = () => {
-  const [users, setUsers] = useState<User[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
   const { currentUser } = useCurrentUser();
-  const myField = currentUser?.field;
+  const { fetchUser, userList, isLoading } = useFetchMembers();
 
   useEffect(() => {
-    try {
-      const getUsers = async () => {
-        const colRef = collection(db, "users");
-        const users = await getDocs(colRef);
-        setUsers(users.docs.map((doc) => doc.data() as User));
-      };
-      getUsers();
-    } finally {
-      setIsLoading(false);
-    }
-  }, [isLoading]);
+    fetchUser();
+  }, []);
 
-  if (!currentUser) return null;
-  const myFieldMembers = users.filter((user) => user.field === myField && user.uid !== currentUser.uid);
+  if (isLoading || userList == null || currentUser == null) return <AppLoading />;
+
+  const myField = currentUser?.field;
+  const displayMyFieldMembers: () => JSX.Element | JSX.Element[] = () => {
+    const myFieldMembers: User[] = userList.filter((user) => {
+      const isMyFieldMember: boolean = user.field === myField;
+      const isNotCurrentUser: boolean = user.uid !== currentUser.uid;
+      return isMyFieldMember && isNotCurrentUser;
+    });
+
+    if (myFieldMembers.length === 0) return <Text>いないようです😭</Text>;
+    return myFieldMembers.map((myFieldMember) => {
+      return <MemberCard key={myFieldMember.uid} data={myFieldMember} />;
+    });
+  };
+
   return (
     <Layout>
-      <Suspense fallback={<AppLoading />}></Suspense>
       <div className="flex w-full flex-col flex-wrap gap-5">
         <div className="pt-5">
           <Text weight="bold">コミッティー</Text>
           <div className="flex flex-wrap gap-5">
-            {users
+            {userList
               .filter((user) => {
                 const isDistinctLeaderPosition = user.position === 3 || user.position === 4 || user.position === 5;
                 return isDistinctLeaderPosition;
               })
-              .map((user, index) => (
-                <ComitteeCard key={index} {...user} />
+              .map((user) => (
+                <ComitteeCard key={user.uid} {...user} />
               ))}
           </div>
         </div>
         <div>
           <Text weight="bold">{myField}を専門としているメンバー</Text>
-          <div className="flex gap-2 rounded-md bg-white py-6 px-4 shadow-md">
-            {myFieldMembers.length === 0 && <Text>いないようです😭</Text>}
-            {myFieldMembers.map((user) => {
-              return <MemberCard key={user.displayName} data={user} />;
-            })}
-          </div>
+          <div className="flex gap-2 rounded-md bg-white py-6 px-4 shadow-md">{displayMyFieldMembers()}</div>
         </div>
-
         <Text weight="bold">全員</Text>
         <div className="flex gap-2 rounded-md bg-white py-6 px-4 shadow-md">
-          {users.map((user, index) => {
-            return <MemberCard data={user} key={index} />;
+          {userList.map((user) => {
+            return <MemberCard data={user} key={user.uid} />;
           })}
         </div>
       </div>
     </Layout>
   );
 };
+
+// TODO: リファクタ 📝
+// 専門メンバーと全員でコンポーネント共通化できそう
+// コミッティーでもできるかも？？
+
+// TODO: 実装メモ 🚧
+// myFieldを設定していない場合どうするのか？？

--- a/src/hooks/user/useFetchUserList.ts
+++ b/src/hooks/user/useFetchUserList.ts
@@ -1,0 +1,22 @@
+import { useState } from "react";
+import { User } from "src/modules/user/user.entity";
+import { userRepository } from "src/modules/user/user.repository";
+
+export const useFetchMembers = () => {
+  const [userList, setUserList] = useState<User[] | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  const fetchUser = async () => {
+    try {
+      const res = await userRepository.find();
+      setUserList(res);
+    } catch (error) {
+      console.log(error);
+      setUserList([]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return { fetchUser, userList, isLoading };
+};

--- a/src/modules/user/user.entity.ts
+++ b/src/modules/user/user.entity.ts
@@ -1,0 +1,19 @@
+export type User = {
+  active: boolean | undefined;
+  bio: string;
+  createdAt: Date;
+  displayName: string | undefined;
+  email: string | undefined;
+  faculty: string | null;
+  field: string | null;
+  fieldDetails: Array<string> | undefined;
+  github: string | undefined;
+  grade: string | null;
+  instagram: string | undefined;
+  photoURL: string;
+  position: number;
+  status: number;
+  twitter: string | undefined;
+  uid: string;
+  university: string;
+};

--- a/src/modules/user/user.repository.ts
+++ b/src/modules/user/user.repository.ts
@@ -1,0 +1,19 @@
+import { collection, doc, getDoc, getDocs } from "firebase/firestore";
+import { db } from "src/components/utils/libs/firebase";
+import { User } from "./user.entity";
+
+export const userRepository = {
+  async find(): Promise<User[]> {
+    const usersCol = collection(db, "users");
+    const res = await getDocs(usersCol);
+    const users = res.docs.map((doc) => doc.data() as User);
+    return users;
+  },
+
+  async findOne(uid: string): Promise<User> {
+    const userRef = doc(db, `users/${uid}`);
+    const res = await getDoc(userRef);
+    const user = res.data() as User;
+    return user;
+  },
+};


### PR DESCRIPTION
## 内容
- 実装がFirebaseにガッツリ依存しているのと、同じ処理を何度もしている(ユーザー一覧取得など)ので、リファクタを兼ねて依存関係の改善を行いました。

### 説明
- 〇〇.entity.tsに、このサービスにおいて使用する型を入れていく
  - Userという型は、FirebaseだとうがSupabaseだろうがNestJSで作ったapiだろうが、その型をもとにこのサービスを作っていくので変わることは基本ない
  - 本当はclassで書いた方がconstractor使えて便利だったりするけど、今回はそこまで使用場面少なそうなので普通にタイプエイリアスにした
- 〇〇.repository.tsに、実際にapiを取得するロジックを記載
  - firebaseから実際に取得してくる処理はここに
  - 基本的にFirebaseに依存しているのが、この中にだけになる

- さらに使いやすくするため、hooksの作成
  - 実際に使用する際には、
    - 取得する関数
    - 取得までのローディング表示用のstate
    - レスポンスの情報を持ってるstate
    - (必要であれば)上のsetState
    を返してあげれば、一行でデータ取得 ~ 表示までの流れを呼び出し側で実行できる
